### PR TITLE
feat(cart): Implementación inicial del sidebar de carrito vacío

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,8 @@ import MainLayout from './layout/MainLayout.jsx';
 import Navbar from './components/Navbar/Navbar.jsx';
 import Footer from './components/Footer/Footer.jsx';
 import Sidebar from './components/Sidebar/Sidebar.jsx';
+import CartSidebar from './components/CartSidebar/CartSidebar.jsx';
+import { CartProvider } from './context/CartContext.jsx';
 import './index.css';
 
 import appRoutes from './routes';
@@ -31,6 +33,8 @@ const MainAppContent = () => {
 
       {shouldShowFullLayout && <Navbar toggleSidebar={toggleSidebar} />}
       {shouldShowFullLayout && <Sidebar isOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />}
+
+      <CartSidebar /> 
 
       {isSidebarOpen && shouldShowFullLayout && (
         <div className="sidebar-overlay" onClick={toggleSidebar}></div>
@@ -62,7 +66,9 @@ function App() {
   return (
     <div className={styles.app}>
       <Router>
+        <CartProvider>
         <MainAppContent />
+        </CartProvider>
       </Router>
     </div>
   );

--- a/src/components/CartSidebar/CartSidebar.jsx
+++ b/src/components/CartSidebar/CartSidebar.jsx
@@ -1,0 +1,106 @@
+import React from 'react'; 
+import { useCart } from '../../context/CartContext';
+import styles from './CartSidebar.module.css';
+import { FaTimes } from 'react-icons/fa';
+import { ShoppingCart } from 'lucide-react';
+
+const CartSidebar = () => {
+  const {
+    cartItems,
+    isCartSidebarOpen,
+    toggleCartSidebar,
+    removeFromCart,
+    updateQuantity,
+    getCartTotal
+  } = useCart();
+
+  const handleQuantityChange = (item, event) => {
+    const newQuantity = parseInt(event.target.value, 10);
+    if (!isNaN(newQuantity) && newQuantity >= 0) {
+      updateQuantity(item.id, newQuantity);
+    }
+  };
+
+  React.useEffect(() => {
+    if (isCartSidebarOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isCartSidebarOpen]);
+
+  return (
+    <>
+      {isCartSidebarOpen && <div className={styles.overlay} onClick={toggleCartSidebar}></div>}
+
+      <div className={`${styles.cartSidebar} ${isCartSidebarOpen ? styles.open : ''}`}>
+        <div className={styles.cartHeader}>
+          <h2>Mi Carrito</h2>
+          <button onClick={toggleCartSidebar} className={styles.closeButton}>
+            <FaTimes />
+          </button>
+        </div>
+
+        <div className={styles.cartItems}>
+          {cartItems.length === 0 ? (
+            <>
+              <p className={styles.emptyCartMessage}>¡Tu carrito está vacío!</p>
+                <ShoppingCart className={styles.emptyCartIcon} size={100} color="#bfbdb9ff" />
+              <p className={styles.emptyCartPrompt}>Parece que todavía no agregaste ningún producto. ¡Explorá el catálogo y encontrá tu estilo!</p>
+              <button className={styles.catalogButton}>Volver al catálogo</button>
+            </>
+          ) : (
+            cartItems.map((item) => (
+              <div key={item.id} className={styles.cartItem}>
+                <img src={item.image} alt={item.name} className={styles.itemImage} />
+                <div className={styles.itemDetails}>
+                  <span className={styles.itemName}>{item.name}</span>
+                  <span className={styles.itemPrice}>${item.price.toFixed(2)}</span>
+                  <div className={styles.itemQuantityControl}>
+                    <button
+                      onClick={() => updateQuantity(item.id, item.quantity - 1)}
+                      disabled={item.quantity <= 1}
+                    >
+                      -
+                    </button>
+                    <input
+                      type="number"
+                      value={item.quantity}
+                      onChange={(e) => handleQuantityChange(item, e)}
+                      min="1"
+                      className={styles.quantityInput}
+                    />
+                    <button onClick={() => updateQuantity(item.id, item.quantity + 1)}>+</button>
+                  </div>
+                  <button onClick={() => removeFromCart(item.id)} className={styles.removeButton}>
+                    Eliminar
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {cartItems.length > 0 && (
+          <div className={styles.cartFooter}>
+            <div className={styles.subtotal}>
+              <span>Subtotal:</span>
+              <span>${getCartTotal().toFixed(2)}</span>
+            </div>
+            <div className={styles.shippingInfo}>
+                Envío gratuito durante 1 año por solo $14.00
+                <button className={styles.addToBagButton}>Añadir a la bolsa</button>
+            </div>
+            <button className={styles.catalogButton}>Volver al catálogo</button>
+            <button className={styles.checkoutButton}>Finalizar compra</button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default CartSidebar;

--- a/src/components/CartSidebar/CartSidebar.module.css
+++ b/src/components/CartSidebar/CartSidebar.module.css
@@ -1,0 +1,256 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 1050;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.cartSidebar {
+  position: fixed;
+  top: 0;
+  right: -350px;
+  width: 350px;
+  height: 100vh;
+  background-color: #010000;
+  box-shadow: -2px 0 10px rgba(0, 0, 0, 0.2);
+  z-index: 1060;
+  display: flex;
+  flex-direction: column;
+  transition: right 0.3s ease-in-out;
+}
+
+.cartSidebar.open {
+  right: 0;
+}
+
+.cartHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 20px;
+  background-color: #010000;
+  color: #F8BD00;
+  border-bottom: 1px solid #333;
+}
+
+.cartHeader h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: #F8BD00;
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.closeButton:hover {
+  color: #fff;
+}
+
+.cartItems {
+  flex-grow: 1;
+  padding: 20px;
+  overflow-y: auto;
+  color: #fff;
+}
+
+.emptyCartMessage {
+  text-align: center;
+  padding: 50px 20px 0;
+  color: #fff;
+  font-style: italic;
+  font-size: 1.2rem;
+}
+
+.emptyCartPrompt {
+    text-align: center;
+    padding: 0 20px 30px;
+    color: #fff;
+    font-size: 0.9rem;
+}
+
+.emptyCartIcon {
+  display: block;
+  margin: 30px auto;
+}
+
+
+.cartItem {
+  display: flex;
+  align-items: center;
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid #fff;
+}
+
+.itemImage {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  margin-right: 15px;
+  border-radius: 5px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.itemDetails {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.itemName {
+  font-weight: bold;
+  font-size: 1.1rem;
+  color: #fff;
+}
+
+.itemPrice {
+  font-size: 0.95rem;
+  color: #fff;
+}
+
+.itemQuantityControl {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 5px;
+}
+
+.itemQuantityControl button {
+  background-color: #eee;
+  border: 1px solid #ddd;
+  padding: 3px 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  border-radius: 3px;
+  color: #333;
+}
+
+.itemQuantityControl button:hover {
+  background-color: #ddd;
+}
+
+.quantityInput {
+  width: 40px;
+  text-align: center;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  padding: 3px 0;
+}
+
+.quantityInput::-webkit-outer-spin-button,
+.quantityInput::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.removeButton {
+  background-color: #dc3545;
+  color: white;
+  border: none;
+  padding: 5px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  margin-top: 10px;
+  align-self: flex-end;
+  transition: background-color 0.2s;
+}
+
+.removeButton:hover {
+  background-color: #c82333;
+}
+
+.cartFooter {
+  padding: 15px 20px;
+  background-color: #eee;
+  border-top: 1px solid #ddd;
+  text-align: right;
+}
+
+.subtotal {
+  display: flex;
+  justify-content: space-between;
+  font-size: 1.2rem;
+  font-weight: bold;
+  margin-bottom: 15px;
+  color: #fff;
+}
+
+.shippingInfo {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.9rem;
+    color: #fff;
+    margin-bottom: 15px;
+}
+
+.addToBagButton {
+    background-color: #fff;
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    transition: background-color 0.2s;
+}
+
+.addToBagButton:hover {
+    background-color: #010000;
+}
+
+.catalogButton {
+  background-color: transparent;
+  color: #fff;
+  border: 2px solid #ffff;
+  padding: 12px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 1.0rem;
+  width: 100%;
+  font-weight: bold;
+  margin-bottom: 4px;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.catalogButton:hover {
+  background-color: #010000;
+  color: #F8BD00;
+}
+
+
+.checkoutButton {
+  background-color: #F8BD00;
+  color: #010000;
+  border: none;
+  padding: 12px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 1.1rem;
+  width: 100%;
+  font-weight: bold;
+  transition: background-color 0.2s;
+}
+
+.checkoutButton:hover {
+  background-color: #e6a700;
+}
+
+
+@media (max-width: 480px) {
+  .cartSidebar {
+    width: 100%;
+    right: -100%;
+  }
+}

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -76,9 +76,29 @@
 }
 
 .cart-button:hover {
-  background-color: #ffffff;
-  color: #010000;
+  background-color: #010000;
+  color: #FFD700;
 }
+
+.cart-button svg {
+  font-size: 1.2rem;
+}
+
+.cart-item-count {
+  position: absolute;
+  top: -8px;
+  right: -5px;
+  background-color: #dc3545;
+  color: white;
+  border-radius: 50%;
+  padding: 2px 6px;
+  font-size: 0.7rem;
+  font-weight: bold;
+  line-height: 1;
+  min-width: 18px;
+  text-align: center;
+}
+
 
 @media (max-width: 768px) {
   .navbar {

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,8 +1,13 @@
 import "./Navbar.css";
 import { Menu, ShoppingCart } from "lucide-react";
-import { Link } from 'react-router-dom'; 
+import { Link } from 'react-router-dom';
+import { useCart } from '../../context/CartContext';
 
 const Navbar = ({ toggleSidebar }) => {
+  const { toggleCartSidebar, cartItems } = useCart();
+
+  const totalItemsInCart = cartItems.reduce((total, item) => total + item.quantity, 0);
+
   return (
     <nav className="navbar">
       <div className="left-group">
@@ -17,9 +22,14 @@ const Navbar = ({ toggleSidebar }) => {
 
       <div className="actions">
         <Link to="/registro" className="login">Ingresar</Link>
-        <button className="cart-button">
+        
+
+        <button onClick={toggleCartSidebar} className="cart-button">
           <ShoppingCart size={16} />
           <span>Mi Carrito</span>
+          {totalItemsInCart > 0 && (
+            <span className="cart-item-count">{totalItemsInCart}</span> 
+          )}
         </button>
       </div>
     </nav>

--- a/src/context/CartContext.jsx
+++ b/src/context/CartContext.jsx
@@ -1,0 +1,84 @@
+import React, { createContext, useState, useContext, useEffect } from 'react';
+
+const CartContext = createContext();
+
+export const CartProvider = ({ children }) => {
+  const [cartItems, setCartItems] = useState(() => {
+    try {
+      const storedCartItems = localStorage.getItem('cartItems');
+      return storedCartItems ? JSON.parse(storedCartItems) : [];
+    } catch (error) {
+      console.error("Failed to load cart from localStorage", error);
+      return [];
+    }
+  });
+  const [isCartSidebarOpen, setIsCartSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('cartItems', JSON.stringify(cartItems));
+    } catch (error) {
+      console.error("Failed to save cart to localStorage", error);
+    }
+  }, [cartItems]);
+
+  const addToCart = (product) => {
+    setCartItems((prevItems) => {
+      const existingItem = prevItems.find((item) => item.id === product.id);
+      if (existingItem) {
+        return prevItems.map((item) =>
+          item.id === product.id ? { ...item, quantity: item.quantity + 1 } : item
+        );
+      } else {
+        return [...prevItems, { ...product, quantity: 1 }];
+      }
+    });
+    setIsCartSidebarOpen(true);
+  };
+
+  const removeFromCart = (productId) => {
+    setCartItems((prevItems) => prevItems.filter((item) => item.id !== productId));
+  };
+
+  const updateQuantity = (productId, newQuantity) => {
+    setCartItems((prevItems) =>
+      prevItems.map((item) =>
+        item.id === productId ? { ...item, quantity: newQuantity } : item
+      ).filter(item => item.quantity > 0)
+    );
+  };
+
+ 
+  const clearCart = () => {
+    setCartItems([]);
+  };
+
+
+  const toggleCartSidebar = () => {
+    setIsCartSidebarOpen((prevState) => !prevState);
+  };
+
+
+  const getCartTotal = () => {
+    return cartItems.reduce((total, item) => total + item.price * item.quantity, 0);
+  };
+
+  return (
+    <CartContext.Provider
+      value={{
+        cartItems,
+        addToCart,
+        removeFromCart,
+        updateQuantity,
+        clearCart,
+        isCartSidebarOpen,
+        toggleCartSidebar,
+        getCartTotal,
+      }}
+    >
+      {children}
+    </CartContext.Provider>
+  );
+};
+
+export const useCart = () => useContext(CartContext);


### PR DESCRIPTION
  - Diseño y lógica para mostrar el carrito vacío con un icono (usando lucide-react).
  - Sección de subtotal y botones de acción ('Volver al catálogo', 'Finalizar compra', 'Añadir a la bolsa').
  - Overlay y animación de deslizamiento para abrir/cerrar.
- **Integración en Navbar.jsx:**
  - Añadido el botón 'Mi Carrito' que abre/cierra el sidebar.