### PR TITLE
feat(UI): UND-68 - Mejoras en el estilo de las tarjetas de productos

### DIFF
--- a/src/components/ProductCard/ProductCard.jsx
+++ b/src/components/ProductCard/ProductCard.jsx
@@ -9,7 +9,7 @@ const ProductCard = ({ product }) => {
   };
 
   return (
-    <div className="bg-gray-900 text-white rounded-lg overflow-hidden shadow-lg flex flex-col">
+    <div className="bg-neutral-900 text-white rounded-lg overflow-hidden shadow-lg flex flex-col">
       <div className="relative w-full aspect-square">
         <img
           src={product.image}
@@ -19,7 +19,7 @@ const ProductCard = ({ product }) => {
       </div>
       <div className="p-4 flex flex-col flex-grow">
         <h3 className="text-lg font-bold mb-1 text-yellow-400">"{product.name}"</h3>
-        <p className="text-sm mb-4 text-gray-300">{product.description}</p>
+        <p className="text-sm mb-4 text-gray-300 line-clamp-3">{product.description}</p>
         <ul className="text-xs text-gray-400 space-y-1 mb-4">
           <li><span className="font-semibold text-yellow-400">Estilo:</span> {product.style}</li>
           <li><span className="font-semibold text-yellow-400">Color base:</span> {product.colorBase}</li>
@@ -27,6 +27,7 @@ const ProductCard = ({ product }) => {
           {product.size && <li><span className="font-semibold text-yellow-400">Talle:</span> {product.size}</li>}
         </ul>
 
+        <div className="mt-auto"></div>
         <Button onClick={handleAddToCart} text={"Agregar al Carrito"}/>
       </div>
     </div>


### PR DESCRIPTION
Se han implementado cambios para asegurar que todas las tarjetas tengan el mismo tamaño, sin importar la longitud de la descripción del producto o la presencia de otros elementos.
-Se ajustó la altura de las tarjetas: Se modificó el estilo de las tarjetas para que su altura sea uniforme en todas las instancias.
-Se limitó la descripción del producto: La descripción ahora está limitada a un máximo de 3 líneas utilizando la clase line-clamp-3 de Tailwind CSS para evitar que las tarjetas se estiren.
-Se alineó el botón "Agregar al Carrito": El botón se ubica siempre en la parte inferior de la tarjeta gracias a la clase mt-auto, garantizando que todas las tarjetas se vean consistentes en la parte inferior.
-Se cambió el color de fondo: El color de fondo de las tarjetas se actualizó a bg-neutral-900 para que coincida con el nuevo esquema de diseño.
<img width="1922" height="972" alt="Captura de pantalla (16)" src="https://github.com/user-attachments/assets/0256c396-b880-4b8c-95e2-a35336152601" />
